### PR TITLE
Feature/dest table

### DIFF
--- a/src/backfill-table.js
+++ b/src/backfill-table.js
@@ -5,9 +5,10 @@ import saveDocument from './save-document';
  * Fill an Elasticsearch type with the contents of a RethinkDB table
  * @param  {String}   r         A handle to the RethinkDB driver
  * @param  {String}   db        The database in RethinkDB to duplicate
+ * @param  {String}   destTable The Elasticsearch type to store the document (defaults to RedthinkDB table name)
  * @param  {String}   table     The table in RethinkDB to duplicate
  */
-function backfillTable(r, { db, table, ...properties }) {
+function backfillTable(r, { db, destTable, table, ...properties }) {
   return new Promise((resolve, reject) => {
     const dataStream = r
       .db(db)
@@ -21,7 +22,7 @@ function backfillTable(r, { db, table, ...properties }) {
             await saveDocument({
               db,
               document: chunk,
-              table,
+              table: destTable || table,
               ...properties
             });
           } catch (e) {

--- a/src/backfill-table.js
+++ b/src/backfill-table.js
@@ -5,10 +5,10 @@ import saveDocument from './save-document';
  * Fill an Elasticsearch type with the contents of a RethinkDB table
  * @param  {String}   r         A handle to the RethinkDB driver
  * @param  {String}   db        The database in RethinkDB to duplicate
- * @param  {String}   destTable The Elasticsearch type to store the document (defaults to RedthinkDB table name)
+ * @param  {String}   esType    The Elasticsearch type to store the document (defaults to RedthinkDB table name)
  * @param  {String}   table     The table in RethinkDB to duplicate
  */
-function backfillTable(r, { db, destTable, table, ...properties }) {
+function backfillTable(r, { db, esType, table, ...properties }) {
   return new Promise((resolve, reject) => {
     const dataStream = r
       .db(db)
@@ -22,7 +22,7 @@ function backfillTable(r, { db, destTable, table, ...properties }) {
             await saveDocument({
               db,
               document: chunk,
-              table: destTable || table,
+              table: esType || table,
               ...properties
             });
           } catch (e) {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -158,7 +158,7 @@ test('can add changes from RethinkDB to elasticsearch', async t => {
     tables: testTableInfo
   });
 
-  await delay(1000);
+  await delay(10000);
 
   await r
     .db(db1)

--- a/src/save-document.js
+++ b/src/save-document.js
@@ -4,6 +4,7 @@ import elasticsearchPath from './elasticsearch-path';
 /**
  * Replicate a document in Elasticsearch
  * @param  {String}   db        The database in RethinkDB the document resides in (used as Elasticsearch index)
+ * @param  {String}   destTable The Elasticsearch type where the document will be stored (defaults to RethinkDB table name)
  * @param  {Object}   document  The document to save.  This may be transformed by `transform`.
  * @param  {String}   table     The table in RethinkDB the document resides in (used as Elasticsearch type)
  * @param  {Function} transform (optional) A function or promise to transform the document before storage in Elasticsearch
@@ -11,6 +12,7 @@ import elasticsearchPath from './elasticsearch-path';
 async function saveDocument({
   baseURL,
   db,
+  destTable,
   document,
   idKey,
   table,
@@ -26,7 +28,7 @@ async function saveDocument({
   const path = elasticsearchPath({
     db,
     id: idKey ? documentToSave[idKey] : null,
-    table
+    table: destTable || table
   });
 
   if (idKey) {

--- a/src/save-document.js
+++ b/src/save-document.js
@@ -4,16 +4,16 @@ import elasticsearchPath from './elasticsearch-path';
 /**
  * Replicate a document in Elasticsearch
  * @param  {String}   db        The database in RethinkDB the document resides in (used as Elasticsearch index)
- * @param  {String}   destTable The Elasticsearch type where the document will be stored (defaults to RethinkDB table name)
  * @param  {Object}   document  The document to save.  This may be transformed by `transform`.
+ * @param  {String}   esType    The Elasticsearch type where the document will be stored (defaults to RethinkDB table name)
  * @param  {String}   table     The table in RethinkDB the document resides in (used as Elasticsearch type)
  * @param  {Function} transform (optional) A function or promise to transform the document before storage in Elasticsearch
  */
 async function saveDocument({
   baseURL,
   db,
-  destTable,
   document,
+  esType,
   idKey,
   table,
   transform
@@ -28,7 +28,7 @@ async function saveDocument({
   const path = elasticsearchPath({
     db,
     id: idKey ? documentToSave[idKey] : null,
-    table: destTable || table
+    table: esType || table
   });
 
   if (idKey) {

--- a/src/save-document.test.js
+++ b/src/save-document.test.js
@@ -65,20 +65,20 @@ test('saveDocument: transform document before saving', async t => {
   t.is(response.status, 200);
 });
 
-test('saveDocument: change dest table', async t => {
-  const destTable = 'test';
+test('saveDocument: change es type', async t => {
+  const esType = 'test';
 
   nock(testData.baseURL)
-    .put(`/cool-people/${destTable}/123`)
+    .put(`/cool-people/${esType}/123`)
     .reply(200, elasticsearchInsertMock);
 
   const response = await saveDocument({
     ...testData,
-    destTable
+    esType
   });
 
   const { data } = response;
-  t.is(data._type, destTable);
+  t.is(data._type, esType);
 });
 
 test('saveDocument: do not save null documents', async t => {

--- a/src/save-document.test.js
+++ b/src/save-document.test.js
@@ -65,6 +65,22 @@ test('saveDocument: transform document before saving', async t => {
   t.is(response.status, 200);
 });
 
+test('saveDocument: change dest table', async t => {
+  const destTable = 'test';
+
+  nock(testData.baseURL)
+    .put(`/cool-people/${destTable}/123`)
+    .reply(200, elasticsearchInsertMock);
+
+  const response = await saveDocument({
+    ...testData,
+    destTable
+  });
+
+  const { data } = response;
+  t.is(data._type, destTable);
+});
+
 test('saveDocument: do not save null documents', async t => {
   const response = await saveDocument({
     ...testData,


### PR DESCRIPTION
Allow the user to specify the esType for a table query so that they can have the query store into a different type from the rethinkdB table name.