### PR TITLE
#31 Adds handling for deleted documents in Rethink

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,25 @@ await rethinkdbElasticsearchStream({
     {
       // Database containing table
       db: 'megacorp',
+      // (optional) Handle when a document is deleted in Rethink
+      // This is detected when the new value for a document is null
+      // If this is not specified, a DELETE is sent to Elasticsearch for the
+      // id of the old value
+      deleteTransform: async ({db, document, oldDocument, table }) => {
+        if (await someImportantCheck()) {
+          return oldDocument;
+        }
+
+        // this is the default behavior for a delete
+        return {
+          // import { _delete } from 'rethinkdb-elasticsearch-stream';
+          //
+          // this is a special Symbol that tells the library that this should
+          // be a DELETE. It can also be used in the regular transform function
+          _delete
+          id: oldDocument.id,
+        }
+      },
       // (optional) Type field for Elasticsearch.  This is similar to a "table" in
       // RethinkDB, and is the second portion of the URL path (index/db is the first).
       esType: 'webUsers',
@@ -73,9 +92,9 @@ await rethinkdbElasticsearchStream({
       // This can be either a function or a Promise.
       // If `null` or `undefined` is returned, the document is not saved.
       // `db` and `table` are specified for convenience
-      transform: async ({ db, document, table }) => {
+      transform: async ({ db, document, oldDocument, table }) => {
         await doSomethingImportant()
-        return document
+        return document;
       }
     }
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethinkdb-elasticsearch-stream",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "main": "build/index.js",
   "repository": "https://github.com/gsandf/rethinkdb-elasticsearch-stream",
   "author": "Blake Knight <bknight@gsandf.com> (http://blakek.me/)",

--- a/src/watch-table.js
+++ b/src/watch-table.js
@@ -15,11 +15,12 @@ function watchTable(r, { db, table, ...properties }) {
     .toStream();
 
   return dataStream.pipe(
-    objectStream(async ({ new_val: chunk }, enc, cb) => {
+    objectStream(async ({ new_val: chunk, old_val: oldDocument }, enc, cb) => {
       try {
         await saveDocument({
           db,
           document: chunk,
+          oldDocument,
           table,
           ...properties
         });


### PR DESCRIPTION
If a document is deleted in Rethink while there's a changefeed watching, it will return:
```
{
new_val: null,
old_val: { someData... }
}
```
This isn't particularly useful to our `transform` function because it would only receive null. This PR updates `saveDocument` and `watchTable` so user-specified `transform` functions now receive `document` and `oldDocument`.

This PR also adds the ability to specify a `deleteTransform`, which runs specifically when `new_val` is null, meaning a delete took place in Rethink. This is a **breaking change**. When a `deleteTransform` is not specified, this library will default to just deleting the document from Elasticsearch, using the id (with respect to the id field) from `oldDocument`. Previously, the document would've just been passed to `transform` as null.