### PR TITLE
Updated log of error to just log the error object

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rethinkdb-elasticsearch-stream",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethinkdb-elasticsearch-stream",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "build/index.js",
   "repository": "https://github.com/gsandf/rethinkdb-elasticsearch-stream",
   "author": "Blake Knight <bknight@gsandf.com> (http://blakek.me/)",

--- a/src/backfill-table.js
+++ b/src/backfill-table.js
@@ -26,9 +26,7 @@ function backfillTable(r, { db, esType, table, ...properties }) {
               ...properties
             });
           } catch (e) {
-            console.log(
-              `ES error for ${e.request.path} [${e.response.status}]`
-            );
+            console.log(`ES error: ${e}`);
           }
 
           cb();

--- a/src/backfill-table.js
+++ b/src/backfill-table.js
@@ -26,7 +26,7 @@ function backfillTable(r, { db, esType, table, ...properties }) {
               ...properties
             });
           } catch (e) {
-            console.log(`ES error: ${e}`);
+            console.log('ES error:', e);
           }
 
           cb();


### PR DESCRIPTION
We were assuming that any error thrown from saveDocument would be a network error, but that's not always the case. This updates the log to just log the error object in case it's not a network error.