### PR TITLE
Added Case-Specific Logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rethinkdb-elasticsearch-stream",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rethinkdb-elasticsearch-stream",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "build/index.js",
   "repository": "https://github.com/gsandf/rethinkdb-elasticsearch-stream",
   "author": "Blake Knight <bknight@gsandf.com> (http://blakek.me/)",

--- a/src/backfill-table.js
+++ b/src/backfill-table.js
@@ -26,7 +26,12 @@ function backfillTable(r, { db, esType, table, ...properties }) {
               ...properties
             });
           } catch (e) {
-            console.log('ES error:', e);
+            const { request, response } = e;
+            if (request && response && request.path) {
+              console.log(`ES error for ${request.path} [${response.status}]`);
+            } else {
+              console.log('ES error', e);
+            }
           }
 
           cb();


### PR DESCRIPTION
Rather than _alway_ logging out the entire error (https://github.com/gsandf/rethinkdb-elasticsearch-stream/pull/35), this will log the path and status code, if applicable. If we don't have those items, then the full error will be logged, as we did before.

Since these are just `console.log`s, I didn't update the test.