### PR TITLE
Utilize library for recovering gracefully changefeeds from connection loss

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,8 @@
   },
   "dependencies": {
     "axios": "^0.17.0",
+    "rethinkdb": "^2.3.3",
+    "rethinkdb-changefeed-reconnect": "^0.3.2",
     "rethinkdbdash": "^2.3.31",
     "through2": "^2.0.3"
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+"bluebird@>= 2.3.2 < 3":
+  version "2.11.0"
+  resolved "http://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+
 "bluebird@>= 3.0.1", bluebird@^3.0.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.0.tgz#791420d7f551eea2897453a8a77653f96606d67c"
@@ -3843,6 +3847,18 @@ restore-cursor@^2.0.0:
   dependencies:
     onetime "^2.0.0"
     signal-exit "^3.0.2"
+
+rethinkdb-changefeed-reconnect@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/rethinkdb-changefeed-reconnect/-/rethinkdb-changefeed-reconnect-0.3.2.tgz#2999f5313205ab35d9ac2d1b0533765ee3376923"
+  dependencies:
+    babel-runtime "^6.18.0"
+
+rethinkdb@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/rethinkdb/-/rethinkdb-2.3.3.tgz#3dc6586e22fa1dabee0d254e64bd0e379fad2f72"
+  dependencies:
+    bluebird ">= 2.3.2 < 3"
 
 rethinkdbdash@^2.3.31:
   version "2.3.31"


### PR DESCRIPTION
For reasons I'm not entirely sure of, sometimes the connection utilized by a changefeed query will get dropped. This leads to a loss of all updates until the service is manually restarted and backfilled. This brings in a library that I have used to solve this problem on a separate occasion. It simply attempts to restore the changefeed if it perceives that it has been lost.